### PR TITLE
Redirect requests to /hpp to Adyen + Show more payment methods

### DIFF
--- a/adyen/main_content.html
+++ b/adyen/main_content.html
@@ -556,11 +556,6 @@
       			
       							displayAmountExtras['card'] = "";
       						
-      									
-      			
-      											addOnLoad(function () {
-      					setTimeout("show(collapsevisa, 'completeCard.shtml', 'card', 'visa')",100);
-      				});
       										
       			if (notNull(document.getElementById('pmmform-visa'))) {
       				document.getElementById('pmmform-visa').setAttribute("autocomplete","off"); 

--- a/adyen/main_content.html
+++ b/adyen/main_content.html
@@ -568,6 +568,679 @@
       </script>
     </div>
   </li>
+
+  <li style="list-style-type: none;">
+   <input   type="submit" name="brandName" value="Credit Card" class="imgB pmB pmBcard"
+    
+      onclick="return show(collapsecard, 'completeCard.shtml', 'card', 'vias');"
+
+  />
+
+      <span id="pmmextracosts-card" class="pmmextracosts">
+          </span>
+
+  <span id="pmcarddescription" class="pmmdescription"></span>
+    <div id="pmmdetails-card" class="pmmdetails">
+          <script type="text/javascript">
+//<![CDATA[
+/* Form validation */
+requiredFields["card"] = new Array();
+requiredFields["card"].push("cardHolderName");
+requiredFields["card"].push("cardNumber");
+requiredFields["card"].push("expiryMonth");
+requiredFields["card"].push("expiryYear");
+errorMessages["card"] = new Array();
+errorMessages["card"]["cardHolderName"] = "Card Holder Name missing";
+errorMessages["card"]["cardNumber"] = "Card Number invalid or missing";
+errorMessages["card"]["expiryMonth"] = "Expiry Month missing";
+errorMessages["card"]["expiryYear"] = "Expiry Year missing";
+errorMessages["card"]["cvcCode"] = "CVC/CVV/CID missing";
+errorMessages["card"]["generic"] = "Please enter your card details";
+
+
+  var cvcinfo = new Array();
+  cvcinfo["mc"] = "<h3>What is CVC?<\/h3>" + 
+                      "<p><img style=\"margin-right: 5px\" class=\"fl\" src=\"/hpp/img/CVC_mini.jpg\" alt=\"CVC location\" />" +
+            "The Card Validation Code (CVC) is an <i>additional<\/i> " + 
+            "three-digit security code that is printed (not embossed) on the back " +
+            "of your card.<\/p>" +
+            "<p>The CVC is an extra security measure to ensure that you are in possession of the card.<\/p><br style=\"clear: both\" />";
+  cvcinfo["visa"] = "<h3>What is CVV?<\/h3>" + 
+                      "<p><img style=\"margin-right: 5px\" class=\"fl\" src=\"/hpp/img/CVV_mini.jpg\" alt=\"CVV location\" />" +
+            "The Card Verification Value (CVV) is an <i>additional<\/i> " + 
+            "three-digit security code that is printed (not embossed) on the back " +
+            "of your card.<\/p>" +
+            "<p>The CVV is an extra security measure to ensure that you are in possession of the card.<\/p><br style=\"clear: both\" />";
+  cvcinfo["amex"] = "<h3>What is CID?<\/h3>" + 
+                      "<p><img style=\"margin-right: 5px\" class=\"fl\" src=\"/hpp/img/CID_mini.jpg\" alt=\"CID location\" />" +
+            "The Card IDentification (CID) is an <i>additional<\/i> " + 
+            "four-digit security code that is printed (not embossed) on the front " +
+            "of your card.<\/p>" +
+            "<p>The CID is an extra security measure to ensure that you are in possession of the card.<\/p><br style=\"clear: both\" />";
+  cvcinfo["card"] = "<h3>What is CVC\/CVV\/CID?<\/h3>" + 
+                      "<p>The Card Security Code (CVC\/CVV\/CID) is an <i>additional<\/i> " + 
+            "three or four digit security code that is printed (not embossed) on the front or the back " +
+            "of your card.<\/p>" +
+            "<p>The CVC\/CVV\/CID is an extra security measure to ensure that you are in possession of the card.<\/p><br style=\"clear: both\" />"; 
+
+  var card_types = new Array();
+  var card_logos = new Array();
+  var card_displayAmountExtras = new Array();
+  var card_extras = new Array();
+  var previousCardNumber ="";
+  var card_subVariantExtras = new Object();
+  var card_subVariantExtrasPhrase = new Object();
+  var originalExtraCostPhrase = document.getElementById('pmmextracosts-card').innerHTML;
+  
+      card_types.push("vias");
+    card_logos.push("/img/pm/vias");
+          card_displayAmountExtras.push("");
+      card_extras.push("");
+    
+                      card_subVariantExtras['vias'] = "";
+        card_subVariantExtrasPhrase['vias'] = "";
+                card_types.push("amex");
+    card_logos.push("/img/pm/amex");
+          card_displayAmountExtras.push("");
+      card_extras.push("");
+    
+                      card_subVariantExtras['amex'] = "";
+        card_subVariantExtrasPhrase['amex'] = "";
+                card_types.push("mc");
+    card_logos.push("/img/pm/mc");
+          card_displayAmountExtras.push("");
+      card_extras.push("");
+    
+                      card_subVariantExtras['mcatm'] = "";
+        card_subVariantExtrasPhrase['mcatm'] = "";
+                        card_subVariantExtras['mccredit'] = "";
+        card_subVariantExtrasPhrase['mccredit'] = "";
+                        card_subVariantExtras['maestro'] = "";
+        card_subVariantExtrasPhrase['maestro'] = "";
+                        card_subVariantExtras['mc'] = "";
+        card_subVariantExtrasPhrase['mc'] = "";
+                        card_subVariantExtras['bijcard'] = "";
+        card_subVariantExtrasPhrase['bijcard'] = "";
+                        card_subVariantExtras['cirrus'] = "";
+        card_subVariantExtrasPhrase['cirrus'] = "";
+                        card_subVariantExtras['mcpro'] = "";
+        card_subVariantExtrasPhrase['mcpro'] = "";
+                        card_subVariantExtras['bcmc'] = "";
+        card_subVariantExtrasPhrase['bcmc'] = "";
+                        card_subVariantExtras['mccommercialcredit'] = "";
+        card_subVariantExtrasPhrase['mccommercialcredit'] = "";
+                        card_subVariantExtras['mcdebit'] = "";
+        card_subVariantExtrasPhrase['mcdebit'] = "";
+                        card_subVariantExtras['mccorporate'] = "";
+        card_subVariantExtrasPhrase['mccorporate'] = "";
+                card_types.push("visa");
+    card_logos.push("/img/pm/visa");
+          card_displayAmountExtras.push("");
+      card_extras.push("");
+    
+                      card_subVariantExtras['visacorporate'] = "";
+        card_subVariantExtrasPhrase['visacorporate'] = "";
+                        card_subVariantExtras['travelmoney'] = "";
+        card_subVariantExtrasPhrase['travelmoney'] = "";
+                        card_subVariantExtras['visabusiness'] = "";
+        card_subVariantExtrasPhrase['visabusiness'] = "";
+                        card_subVariantExtras['visahipotecario'] = "";
+        card_subVariantExtrasPhrase['visahipotecario'] = "";
+                        card_subVariantExtras['visacredit'] = "";
+        card_subVariantExtrasPhrase['visacredit'] = "";
+                        card_subVariantExtras['visapurchasing'] = "";
+        card_subVariantExtrasPhrase['visapurchasing'] = "";
+                        card_subVariantExtras['visaproprietary'] = "";
+        card_subVariantExtrasPhrase['visaproprietary'] = "";
+                        card_subVariantExtras['visaclassic'] = "";
+        card_subVariantExtrasPhrase['visaclassic'] = "";
+                        card_subVariantExtras['visaplatinum'] = "";
+        card_subVariantExtrasPhrase['visaplatinum'] = "";
+                        card_subVariantExtras['visasignature'] = "";
+        card_subVariantExtrasPhrase['visasignature'] = "";
+                        card_subVariantExtras['electron'] = "";
+        card_subVariantExtrasPhrase['electron'] = "";
+                        card_subVariantExtras['visacommercialcredit'] = "";
+        card_subVariantExtrasPhrase['visacommercialcredit'] = "";
+                        card_subVariantExtras['visagold'] = "";
+        card_subVariantExtrasPhrase['visagold'] = "";
+                        card_subVariantExtras['visa'] = "";
+        card_subVariantExtrasPhrase['visa'] = "";
+                        card_subVariantExtras['visadebit'] = "";
+        card_subVariantExtrasPhrase['visadebit'] = "";
+            
+    
+  var baseURL = "/hpp/";
+  if(baseURL.indexOf(";jsession") != -1) {
+    baseURL = baseURL.substr(0,baseURL.indexOf(";jsession"));
+  }
+  
+  function validateCcNumber(e, dontHideErrorFrame) {
+    cardNumber = (document.getElementById('cardNumber').value);
+    
+    if(cardNumber.length <= previousCardNumber.length) {
+      previousCardNumber = cardNumber;
+      if (cardNumber.length == 0) {
+        resetExtraCost();
+      }
+      return;
+    }
+    var l=0;
+    while(l < previousCardNumber.length) {
+      if(cardNumber[l] != previousCardNumber[l]) {
+        previousCardNumber = cardNumber;
+        return;
+      } 
+      l++;
+    }
+  
+    reg = /\s+/g;
+    cardNumber = cardNumber.replace(reg,'');
+    
+    nrOfDigits = cardNumber.length;
+    
+    if(nrOfDigits > 19){
+      ccNumberPresentation(false);
+      return;
+    }
+    
+    ccNumberPresentation(true,dontHideErrorFrame);
+    
+    baseCard = getBaseCard(cardNumber,card_types);
+    if(baseCard != null) {
+        setCardBrand(baseCard, true);
+    } else if(nrOfDigits > 4) {
+        setCardBrand(null, true);
+      ccNumberPresentation(false);
+    } else {
+      setCardBrand(null, false);
+    }
+
+    if (cardNumber.length < 6) {
+      setExtraCost(baseCard, null);
+    } else if (cardNumber.length == 6 || cardNumber.length == 9 || cardNumber.length == 12){
+      _.X("/hpp/binLookup.shtml",function(d,r){
+        if(r.status != 200 || d.indexOf('"result"') == -1) return false;
+              var response=eval("("+d+")");
+          
+        if(typeof(response.result)=='undefined') return false;
+    
+        if (response.result == 0) {
+          lookedUpCardType = response.cardType;
+        } else {
+          lookedUpCardType = null;  
+        }
+        setExtraCost(baseCard, lookedUpCardType);
+    
+        return true;
+          }, 'bin='+cardNumber+'&'+_.Q(_.G("pageform")));
+    }
+    
+    //show value with white space after four numbers
+    result = cardNumber.replace(/(\d{4})/g, '$1 ');
+    result = result.replace(/\s+$/, ''); //remove trailing spaces
+    
+    previousCardNumber = result;
+    document.getElementById('cardNumber').value = result;
+  }
+  
+  function setExtraCost(selectedCard, lookedUpCard) {
+    var extraCostDisplayed = false;
+    if (lookedUpCard != null && card_subVariantExtras[lookedUpCard] != null) {
+      document.getElementById('extraCostAmount').innerHTML = card_subVariantExtras[lookedUpCard];
+      displayAmountExtras['card'] = card_subVariantExtras[lookedUpCard];
+      document.getElementById('pmmextracosts-card').innerHTML = card_subVariantExtrasPhrase[lookedUpCard];
+      extraCostDisplayed = true;
+    } else {
+                for(var i = 0; i < card_types.length; ++i) {
+          if(selectedCard != null && card_types[i] == selectedCard.cardtype && card_subVariantExtras[selectedCard.cardtype] != null) {
+          document.getElementById('extraCostAmount').innerHTML = card_subVariantExtras[selectedCard.cardtype];
+          displayAmountExtras['card'] = card_subVariantExtras[selectedCard.cardtype];
+          document.getElementById('pmmextracosts-card').innerHTML = card_subVariantExtrasPhrase[selectedCard.cardtype];
+          extraCostDisplayed = true;
+          }
+          }
+    }
+    
+    if (!extraCostDisplayed) {
+      resetExtraCost();
+    }
+  }
+  
+  function resetExtraCost() {
+    displayAmountExtras['card'] = "";
+    document.getElementById('extraCostAmount').innerHTML = "";
+    document.getElementById('pmmextracosts-card').innerHTML = originalExtraCostPhrase;
+  }
+  
+  function setCardBrand(selectedCard, greyInactive) {
+
+    for(var i = 0; i < card_types.length; ++i) {
+        var imageId = "cclogo" + i;
+      if(selectedCard != null && card_types[i] == selectedCard.cardtype) {
+        document.getElementById(imageId).src=baseURL + card_logos[i] + "_small.png";
+      } else {
+          if(greyInactive) {
+          document.getElementById(imageId).src=baseURL + card_logos[i] + "_small_grey.png";
+        } else {
+          document.getElementById(imageId).src=baseURL + card_logos[i] + "_small.png";
+        }
+      }
+      document.getElementById(imageId).style.display="inline";
+    }
+    if(selectedCard != null) {
+      if(selectedCard.cardtype == "amex") {
+      document.getElementById("cvcCode").maxLength = 4;
+      document.getElementById('cvcName').innerHTML = "CID";
+      document.getElementById('cvcWhatIs').innerHTML = "What is CID?";
+      document.getElementById('cvcFrame').innerHTML = cvcinfo["amex"];
+      } else if (selectedCard.cardtype == "visa" || selectedCard.cardtype == "electron") {
+        document.getElementById("cvcCode").maxLength = 3;
+      document.getElementById('cvcName').innerHTML = "CVV";
+      document.getElementById('cvcWhatIs').innerHTML = "What is CVV?";
+      document.getElementById('cvcFrame').innerHTML = cvcinfo["visa"];
+      } else if (selectedCard.cardtype == "mc" || selectedCard.cardtype == "maestro" || selectedCard.cardtype == "maestrouk" || selectedCard.cardtype == "solo" ) {
+        document.getElementById("cvcCode").maxLength = 3;
+      document.getElementById('cvcName').innerHTML = "CVC";
+      document.getElementById('cvcWhatIs').innerHTML = "What is CVC?";
+      document.getElementById('cvcFrame').innerHTML = cvcinfo["mc"];
+      } else {
+        document.getElementById("cvcCode").maxLength = 3;
+      document.getElementById('cvcName').innerHTML = "CVC";
+      document.getElementById('cvcWhatIs').innerHTML = "What is CVC?";
+      document.getElementById('cvcFrame').innerHTML = cvcinfo["card"];
+      }  
+    }
+  }
+    
+  function ccNumberPresentation(valid, dontHideErrorFrame){
+    var errors = new Array();
+    errors.push("cardNumber");
+    if(valid){
+      clearErrors(errors, dontHideErrorFrame);
+    }
+    else{
+      markErrorFields(errors);
+    }
+  }
+  
+  function blockNonNumbers(e) {
+    var key;
+    var isCtrl = false;
+    var keychar;
+    var reg;
+      
+    if(window.event) {
+      key = e.keyCode;
+      isCtrl = window.event.ctrlKey
+    }
+    else if(e.which) {
+      key = e.which;
+      isCtrl = e.ctrlKey;
+    }
+    
+    if (isNaN(key)) return true;
+    
+    keychar = String.fromCharCode(key);
+    
+    // check for backspace or delete, or if Ctrl was pressed
+    if (key == 8 || isCtrl) {
+      return true;
+    }
+  
+    reg = /[\d ]/;
+    
+    return reg.test(keychar);
+  }
+  
+  validationFunctions
+  function doCCCheck(){
+    cardNumber = (document.getElementById('cardNumber').value);
+    reg = /\s+/g;
+    cardNumber = cardNumber.replace(reg,'');
+    if(!luhnCheck(cardNumber))
+      ccNumberPresentation(false);
+    else
+      ccNumberPresentation(true);
+  }
+    
+  validationFunctions["card"] = new Array();
+  validationFunctions["card"]["cardNumber"] = function (cardNumberField) {
+    cardNumber = cardNumberField.value;
+    reg = /\s+/g;
+    cardNumber = cardNumber.replace(reg,'');
+    if(cardNumber == "" || luhnCheck(cardNumber)){
+      return true;
+    }
+    return false;
+  }
+
+  
+
+//]]>
+</script>
+
+<table class="basetable">
+<tr>
+    <td class="mid"><div id="cclogoheader" style="display: none">Card Type</div></td>
+
+    <td class="mid">
+        <div style="height: 25px" id="cclogo">
+          <img alt="" id="cclogo0" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <img alt="" id="cclogo1" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <img alt="" id="cclogo2" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <img alt="" id="cclogo3" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <img alt="" id="cclogo4" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <img alt="" id="cclogo5" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <img alt="" id="cclogo6" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+
+          <img alt="" id="cclogo7" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <img alt="" id="cclogo8" style="display: none" class="mid" src="/hpp/img/pm/unknown_small.png" />
+          <script type="text/javascript">
+            setCardBrand(null, false);
+          </script>
+      </div>
+    </td>
+</tr>
+<tr id="cardNumberTr">
+        <td><div>Card Number</div></td>
+        <td><div class="fieldDiv"><input type="text" class="inputField" id="cardNumber" 
+            onkeypress="return blockNonNumbers(event)" onkeyup="validateCcNumber(event)" onblur="validateCcNumber(event)" onchange="doCCCheck()"
+            name="cardNumber" value=""                           size="24" maxlength="23" 
+                                              /></div></td>
+
+</tr>
+<tr>
+        <td><div>Card Holder Name</div></td>
+        <td><div class="fieldDiv"><input type="text" class="inputField" id="cardHolderName" name="cardHolderName" value="" size="19" maxlength="30" /></div></td>
+</tr>
+
+<tr>
+        <td><div>Card Expiry Date</div></td><td>
+        <div class="fieldDiv">
+        <select class="inputField" name="expiryMonth" id="expiryMonth" size="1">
+
+        <option value="*">&nbsp;</option>
+        <option  value="01">01</option>
+        <option  value="02">02</option>
+        <option  value="03">03</option>
+        <option  value="04">04</option>
+        <option  value="05">05</option>
+
+        <option  value="06">06</option>
+        <option  value="07">07</option>
+        <option  value="08">08</option>
+        <option  value="09">09</option>
+        <option  value="10">10</option>
+        <option  value="11">11</option>
+
+        <option  value="12">12</option>
+        </select>
+         &nbsp;/&nbsp; 
+        <select class="inputField" name="expiryYear" id="expiryYear" size="1">
+        <option value="*">&nbsp;</option>
+        <option  value="2011">2011</option>
+        <option  value="2012">2012</option>
+
+        <option  value="2013">2013</option>
+        <option  value="2014">2014</option>
+        <option  value="2015">2015</option>
+        <option  value="2016">2016</option>
+        <option  value="2017">2017</option>
+        <option  value="2018">2018</option>
+
+        <option  value="2019">2019</option>
+        <option  value="2020">2020</option>
+        <option  value="2021">2021</option>
+        <option  value="2022">2022</option>
+    <option  value="2023">2023</option>
+    <option  value="2024">2024</option>
+
+    <option  value="2025">2025</option>
+        <option  value="2026">2026</option>
+        <option  value="2027">2027</option>
+    </select>
+        </div>
+        </td>
+</tr>
+
+<tr>
+        <td><div id="cvcName">CVC/CVV/CID</div></td>
+        <td><div class="fieldDiv"><input class="inputField" type="text" name="cvcCode"  value="" id="cvcCode" size="7" maxlength="3" /> &nbsp; <a href="#"  onclick="return toggleElement('cvcFrame');"><span id="cvcWhatIs">What is CVC/CVV/CID?</span></a></div></td>
+</tr>
+
+
+  <tr>
+      <td colspan="2"><div class="r">
+                            <input class="paySubmit paySubmitcard" type="submit" name="pay" value="pay" />
+
+                </div></td>
+    </tr>
+</table>
+
+
+<div class="popupMsg  popupMsgOPP " style="display: none;" onclick="return hideElement('cvcFrame');" id="cvcFrame">
+  <h3>What is CVC/CVV/CID?</h3>
+  <p>The Card Security Code (CVC/CVV/CID) is an <i>additional</i>
+          three or four digit security code that is printed (not embossed) on the front or the back
+        of your card.</p>
+
+    <p>The CVC/CVV/CID is an extra security measure to ensure that you are in possession of the card.</p>
+</div>
+
+
+<script type="text/javascript">
+//<![CDATA[
+
+  if(document.getElementById('cardNumber').value.length > 0) {
+    var validateCcNumberTimer = setTimeout('validateCcNumber(null,true)', 2500);
+  }
+
+//]]>
+</script>
+
+        <script type="text/javascript">
+      var collapsecard = new animatedcollapse("pmmdetails-card", 1000, false, false, config["pmmanimation"]==1?false:true);
+      details.push(collapsecard);
+      
+              displayAmountExtras['card'] = "";
+            
+                  
+      
+            
+      if (notNull(document.getElementById('pmmform-card'))) {
+        document.getElementById('pmmform-card').setAttribute("autocomplete","off"); 
+      }
+    </script>
+  </div>
+  </li>
+
+  <li style="list-style-type: none;">
+
+   <input   type="submit" name="brandName" value="iDEAL" class="imgB pmB pmBideal"
+    
+      onclick="return show(collapseideal, 'redirectIdeal.shtml', 'ideal', 'ideal');"
+
+  />
+      <span id="pmmextracosts-ideal" class="pmmextracosts">
+          </span>
+
+  <span id="pmidealdescription" class="pmmdescription"></span>
+    <div id="pmmdetails-ideal" class="pmmdetails">
+          
+<script type="text/javascript">
+//<![CDATA[
+/* Form validation */
+errorMessages["ideal"] = new Array();
+errorMessages["ideal"]["idealIssuerId"] = "U heeft een ongeldige bank gekozen";
+//]]>
+</script>
+
+<style type="text/css">
+  .idealButton {
+    width:120px;
+    height:40px;
+    border:0px;
+    font-size:0;
+    cursor: pointer; /* hand-shaped cursor */
+      cursor: hand; /* for IE 5.x */
+  }
+  .idealButtonPadding {
+    padding-left: 20px;
+  }
+</style>
+
+<table class="basetable">
+
+  
+                            
+                                
+            <tr>
+      <td>
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK1.png);" value="1121" name="idealIssuer"/>
+    </td>
+            
+                            
+                                
+            <td class="idealButtonPadding">
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK2.png);" value="1151" name="idealIssuer"/>
+    </td>
+
+              </tr>
+        
+                            
+                                
+            <tr>
+      <td>
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK3.png);" value="1152" name="idealIssuer"/>
+    </td>
+            
+                            
+                                
+            <td class="idealButtonPadding">
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK4.png);" value="1153" name="idealIssuer"/>
+    </td>
+              </tr>
+
+        
+                            
+                                
+            <tr>
+      <td>
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK5.png);" value="1154" name="idealIssuer"/>
+    </td>
+            
+                            
+                                
+            <td class="idealButtonPadding">
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK6.png);" value="1155" name="idealIssuer"/>
+    </td>
+              </tr>
+        
+                            
+                                
+            <tr>
+
+      <td>
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK7.png);" value="1156" name="idealIssuer"/>
+    </td>
+            
+                            
+                                
+            <td class="idealButtonPadding">
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK8.png);" value="1157" name="idealIssuer"/>
+    </td>
+              </tr>
+        
+                            
+                                
+            <tr>
+      <td>
+
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK9.png);" value="1158" name="idealIssuer"/>
+    </td>
+            
+                            
+                                
+            <td class="idealButtonPadding">
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANK10.png);" value="1159" name="idealIssuer"/>
+    </td>
+              </tr>
+      
+  
+                        
+                            
+            <tr>
+      <td>
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANKREFUSED.png);" value="1160" name="idealIssuer"/>
+
+    </td>
+            
+                        
+                            
+            <td class="idealButtonPadding">
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANKPENDING.png);" value="1161" name="idealIssuer"/>
+    </td>
+              </tr>
+        
+                        
+                          
+            <tr>
+      <td>
+        <input type="submit" class="idealButton" style="background-image: url(/hpp/img/pm/TESTBANKCANCELLED.png);" value="1162" name="idealIssuer"/>
+    </td>
+
+          
+            <td></td>
+                    </tr>
+                    </tr>
+      
+<tr>
+        <td colspan="2"><div class="fieldDiv">
+          <select class="inputField" id="idealIssuerId" name="idealIssuerId">
+            <option value="0">Kies uw bank...</option>
+                          <option value="1121">Test Issuer</option>
+
+                      <option value="1151">Test Issuer 2</option>
+                      <option value="1152">Test Issuer 3</option>
+                      <option value="1153">Test Issuer 4</option>
+                      <option value="1154">Test Issuer 5</option>
+                      <option value="1155">Test Issuer 6</option>
+                      <option value="1156">Test Issuer 7</option>
+
+                      <option value="1157">Test Issuer 8</option>
+                      <option value="1158">Test Issuer 9</option>
+                      <option value="1159">Test Issuer 10</option>
+                            <option value="0">---Overige banken---</option>
+                                  <option value="1160">Test Issuer Refused</option>
+                          <option value="1161">Test Issuer Pending</option>
+
+                          <option value="1162">Test Issuer Cancelled</option>
+                  </select>
+    </div></td>         
+</tr>
+  <tr>
+      <td colspan="2"><div class="r"> 
+      <input  class="paySubmit paySubmitideal" type="submit" name="pay" value="continue" />
+    </div></td>
+    </tr>
+
+</table>
+        <script type="text/javascript">
+      var collapseideal = new animatedcollapse("pmmdetails-ideal", 1000, false, false, config["pmmanimation"]==1?false:true);
+      details.push(collapseideal);
+      
+              displayAmountExtras['ideal'] = "";
+            
+                  
+      
+            
+      if (notNull(document.getElementById('pmmform-ideal'))) {
+        document.getElementById('pmmform-ideal').setAttribute("autocomplete","off"); 
+      }
+    </script>
+  </div>
+  </li>
 </ul>
 
 <div id="errorFrame" style="display: none;" class="popupMsg errorFrame">


### PR DESCRIPTION
Hi Priit,

while developing skins where multiple payment methods will be used, I needed to have more than one during development as well (to style first, middle and list items different). So I added two methods to the template (just any 2 - I can imagine a configuration option for this, but for me that's overkill).

The other part of this pull request is the redirection of files under /hpp to the Adyen test server, so all images (e.g. in the iDeal payment method) load properly. This was the feature issue you had listed, I think?

Cheers,
Corné
